### PR TITLE
fix: correct absolute path vs relative path for GHFile and GHBlame

### DIFF
--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -31,7 +31,7 @@ function M.setup()
   vim.api.nvim_create_user_command('GHBlame', function(command)
     local filename = command.args
     if filename == '' then
-      filename = vim.fn.expand('%')
+      filename = vim.fn.expand('%:.')
     end
 
     if command.range == 0 then
@@ -45,7 +45,7 @@ function M.setup()
   vim.api.nvim_create_user_command('GHFile', function(command)
     local filename = command.args
     if filename == '' then
-      filename = vim.fn.expand('%')
+      filename = vim.fn.expand('%:.')
     end
 
     if command.range == 0 then


### PR DESCRIPTION
I encountered a 404 error using `GHFile`. `GHFile` was linking to the absolute path of my project instead of the relative path. Made the change to `GHFile` and `GHBlame` to point to the correct paths in GitHub.

Fixes #1