### PR TITLE
feat: support passing commit SHA or PR query as direct argument to GH

### DIFF
--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -117,7 +117,12 @@ function M.setup()
       local args = #fargs > 1 and vim.list_slice(fargs, 2, #fargs) or {}
       local subcommand = subcommand_tbl[subcommand_key]
       if not subcommand then
-        vim.notify('Unknown command: ' .. subcommand_key, vim.log.levels.ERROR, { title = 'GH Navigator' })
+        local arg = opts.args
+        if utils.is_commit(arg) then
+          utils.open_commit(arg, opts.bang)
+        else
+          utils.open_pr(arg, opts.bang)
+        end
         return
       end
       subcommand.call(args, opts)


### PR DESCRIPTION
## Summary
- When the first argument to `GH` isn't a recognized subcommand, treat the full argument string as a commit SHA or PR query instead of erroring
- Enables `GH eef4a114e0bacc929d8335ef52b1b859d40097f4` to open a commit and `GH 1234` to open a PR directly
- The cursor-based behavior (`GH` with no arguments) is unchanged

## Test plan
- [ ] Run `GH eef4a114` with a valid commit SHA and verify it opens the commit on GitHub
- [ ] Run `GH 1234` with a valid PR number and verify it opens the PR
- [ ] Run `GH some search term` and verify it searches for a matching PR
- [ ] Run `GH` with no arguments and cursor on a SHA — verify cursor-based behavior still works
- [ ] Run `GH browse`, `GH blame`, etc. — verify subcommands still work