### PR TITLE
ci: add PR auto-assign workflow

### DIFF
--- a/.github/workflows/pr-assign.yml
+++ b/.github/workflows/pr-assign.yml
@@ -1,0 +1,13 @@
+name: Pull Assign
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: planningcenter/pull-assign-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to auto-assign PRs to their author

## Context
This workflow automatically assigns pull requests to the person who opened them, improving PR tracking and notifications.

Uses: https://github.com/planningcenter/pull-assign-action