### PR TITLE
test: add plenary.nvim test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Clone plenary.nvim
         run: git clone --depth 1 https://github.com/nvim-lua/plenary.nvim /tmp/plenary.nvim
       - name: Run tests
-        run: PLENARY_DIR=/tmp/plenary.nvim nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
+        run: PLENARY_DIR=/tmp/plenary.nvim nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
+        timeout-minutes: 5
   docs:
     name: vimdoc
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,20 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
-          args: --color always --check lua/
+          args: --color always --check lua/ tests/
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: v0.10.0
+      - name: Clone plenary.nvim
+        run: git clone --depth 1 https://github.com/nvim-lua/plenary.nvim /tmp/plenary.nvim
+      - name: Run tests
+        run: PLENARY_DIR=/tmp/plenary.nvim nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
   docs:
     name: vimdoc
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   stylua:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,8 @@ jobs:
         with:
           neovim: true
           version: v0.10.0
-      - name: Clone plenary.nvim
-        run: git clone --depth 1 https://github.com/nvim-lua/plenary.nvim /tmp/plenary.nvim
       - name: Run tests
-        run: PLENARY_DIR=/tmp/plenary.nvim nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
+        run: make test
         timeout-minutes: 5
   docs:
     name: vimdoc

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ plenary:
 	fi
 
 test: plenary
-	PLENARY_DIR=$(PLENARY_DIR) nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
+	PLENARY_DIR=$(PLENARY_DIR) nvim --headless -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
 
 lint:
 	stylua --check lua/ tests/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+PLENARY_DIR ?= /tmp/plenary.nvim
+
+.PHONY: test plenary lint
+
+plenary:
+	@if [ ! -d "$(PLENARY_DIR)" ]; then \
+		git clone --depth 1 https://github.com/nvim-lua/plenary.nvim $(PLENARY_DIR); \
+	fi
+
+test: plenary
+	PLENARY_DIR=$(PLENARY_DIR) nvim --headless -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
+
+lint:
+	stylua --check lua/ tests/

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -1,0 +1,103 @@
+local M = {}
+
+local _originals = {}
+local _system_patterns = {}
+
+--- Program vim.fn.system to return `response` when command contains `pattern` (plain substring match).
+---@param pattern string plain substring to match against the command string
+---@param response string value vim.fn.system should return
+function M.set_system_response(pattern, response)
+  table.insert(_system_patterns, { pattern = pattern, response = response })
+end
+
+--- Remove all programmed system responses so the next test can start fresh.
+function M.clear_system_responses()
+  _system_patterns = {}
+end
+
+--- Install mocks for vim.fn.system, vim.fn.executable, vim.fn.setreg,
+--- vim.fn.expand, vim.ui.open, vim.ui.select, and vim.notify.
+function M.setup_mocks()
+  _system_patterns = {}
+
+  _originals = {
+    ui_open = vim.ui.open,
+    ui_select = vim.ui.select,
+    notify = vim.notify,
+  }
+
+  -- Pattern-matched system mock
+  vim.fn.system = function(cmd)
+    local cmd_str = type(cmd) == 'table' and table.concat(cmd, ' ') or cmd
+    for _, entry in ipairs(_system_patterns) do
+      if cmd_str:find(entry.pattern, 1, true) then
+        return entry.response
+      end
+    end
+    return ''
+  end
+
+  vim.fn.executable = function(_)
+    return 1
+  end
+
+  M.last_register = nil
+  M.last_register_value = nil
+  vim.fn.setreg = function(reg, value)
+    M.last_register = reg
+    M.last_register_value = value
+  end
+
+  M.expand_result = nil
+  vim.fn.expand = function(expr)
+    return M.expand_result or expr
+  end
+
+  M.opened_url = nil
+  vim.ui.open = function(url)
+    M.opened_url = url
+  end
+
+  M.select_items = nil
+  vim.ui.select = function(items, _, on_choice)
+    M.select_items = items
+    if #items > 0 then
+      on_choice(items[1])
+    end
+  end
+
+  M.notifications = {}
+  vim.notify = function(msg, level, opts)
+    table.insert(M.notifications, { msg = msg, level = level, opts = opts })
+  end
+end
+
+--- Revert all stubs installed by setup_mocks().
+function M.teardown_mocks()
+  -- Remove direct entries from vim.fn so the metatable __index resumes
+  rawset(vim.fn, 'system', nil)
+  rawset(vim.fn, 'executable', nil)
+  rawset(vim.fn, 'setreg', nil)
+  rawset(vim.fn, 'expand', nil)
+
+  if _originals.ui_open then
+    vim.ui.open = _originals.ui_open
+  end
+  if _originals.ui_select then
+    vim.ui.select = _originals.ui_select
+  end
+  if _originals.notify then
+    vim.notify = _originals.notify
+  end
+
+  _originals = {}
+  _system_patterns = {}
+  M.last_register = nil
+  M.last_register_value = nil
+  M.opened_url = nil
+  M.select_items = nil
+  M.notifications = {}
+  M.expand_result = nil
+end
+
+return M

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -1,0 +1,390 @@
+local helpers = require('helpers')
+
+describe('gh-navigator', function()
+  local captured_gh_cmd, captured_complete
+  local spy_calls
+  local is_commit_return
+
+  local function setup_plugin()
+    spy_calls = {}
+    is_commit_return = false
+
+    package.loaded['gh-navigator'] = nil
+    package.loaded['gh-navigator.init'] = nil
+    package.loaded['gh-navigator.utils'] = nil
+
+    local utils = require('gh-navigator.utils')
+    utils.gh_cli_installed = function()
+      return true
+    end
+    utils.in_github_repo = function()
+      return true
+    end
+    utils.is_commit = function(arg)
+      table.insert(spy_calls, { fn = 'is_commit', args = { arg } })
+      return is_commit_return
+    end
+    utils.open_commit = function(sha, bang)
+      table.insert(spy_calls, { fn = 'open_commit', args = { sha, bang } })
+    end
+    utils.open_pr = function(arg, bang)
+      table.insert(spy_calls, { fn = 'open_pr', args = { arg, bang } })
+    end
+    utils.open_blame = function(filename, bang)
+      table.insert(spy_calls, { fn = 'open_blame', args = { filename, bang } })
+    end
+    utils.open_file = function(filename, bang)
+      table.insert(spy_calls, { fn = 'open_file', args = { filename, bang } })
+    end
+    utils.open_repo = function(path, bang)
+      table.insert(spy_calls, { fn = 'open_repo', args = { path, bang } })
+    end
+
+    -- Capture the command callback and completion function
+    local orig_create = vim.api.nvim_create_user_command
+    vim.api.nvim_create_user_command = function(name, callback, opts)
+      if name == 'GH' then
+        captured_gh_cmd = callback
+        captured_complete = opts.complete
+      end
+      orig_create(name, callback, opts)
+    end
+
+    require('gh-navigator').setup()
+
+    vim.api.nvim_create_user_command = orig_create
+  end
+
+  before_each(function()
+    helpers.setup_mocks()
+    pcall(vim.api.nvim_del_user_command, 'GH')
+    setup_plugin()
+  end)
+
+  after_each(function()
+    pcall(vim.api.nvim_del_user_command, 'GH')
+    helpers.teardown_mocks()
+  end)
+
+  -- Helper: filter spy_calls by function name
+  local function calls_to(fn_name)
+    return vim.tbl_filter(function(c)
+      return c.fn == fn_name
+    end, spy_calls)
+  end
+
+  describe('setup', function()
+    it('does not create GH command when gh cli is not installed', function()
+      pcall(vim.api.nvim_del_user_command, 'GH')
+
+      package.loaded['gh-navigator'] = nil
+      package.loaded['gh-navigator.init'] = nil
+      package.loaded['gh-navigator.utils'] = nil
+
+      local utils = require('gh-navigator.utils')
+      utils.gh_cli_installed = function()
+        return false
+      end
+      utils.in_github_repo = function()
+        return true
+      end
+
+      require('gh-navigator').setup()
+
+      assert.equals(0, vim.fn.exists(':GH'))
+    end)
+
+    it('does not create GH command when not in github repo', function()
+      pcall(vim.api.nvim_del_user_command, 'GH')
+
+      package.loaded['gh-navigator'] = nil
+      package.loaded['gh-navigator.init'] = nil
+      package.loaded['gh-navigator.utils'] = nil
+
+      local utils = require('gh-navigator.utils')
+      utils.gh_cli_installed = function()
+        return true
+      end
+      utils.in_github_repo = function()
+        return false
+      end
+
+      require('gh-navigator').setup()
+
+      assert.equals(0, vim.fn.exists(':GH'))
+    end)
+
+    it('registers GH command when guards pass', function()
+      assert.equals(2, vim.fn.exists(':GH'))
+    end)
+  end)
+
+  describe('command dispatch', function()
+    it('calls open_commit when word under cursor is a commit', function()
+      is_commit_return = true
+      helpers.expand_result = 'abc123'
+
+      captured_gh_cmd({
+        args = '',
+        fargs = {},
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local commits = calls_to('open_commit')
+      assert.equals(1, #commits)
+      assert.equals('abc123', commits[1].args[1])
+      assert.is_false(commits[1].args[2])
+    end)
+
+    it('calls open_pr when word under cursor is not a commit', function()
+      is_commit_return = false
+      helpers.expand_result = 'some-word'
+
+      captured_gh_cmd({
+        args = '',
+        fargs = {},
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local prs = calls_to('open_pr')
+      assert.equals(1, #prs)
+      assert.equals('some-word', prs[1].args[1])
+      assert.is_false(prs[1].args[2])
+    end)
+
+    it('dispatches browse subcommand to open_file', function()
+      helpers.expand_result = 'current_file.lua'
+
+      captured_gh_cmd({
+        args = 'browse',
+        fargs = { 'browse' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local files = calls_to('open_file')
+      assert.equals(1, #files)
+      assert.equals('current_file.lua', files[1].args[1])
+    end)
+
+    it('dispatches browse with explicit filename', function()
+      captured_gh_cmd({
+        args = 'browse lua/init.lua',
+        fargs = { 'browse', 'lua/init.lua' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local files = calls_to('open_file')
+      assert.equals(1, #files)
+      assert.equals('lua/init.lua', files[1].args[1])
+    end)
+
+    it('dispatches blame subcommand to open_blame', function()
+      helpers.expand_result = 'current_file.lua'
+
+      captured_gh_cmd({
+        args = 'blame',
+        fargs = { 'blame' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local blames = calls_to('open_blame')
+      assert.equals(1, #blames)
+      assert.equals('current_file.lua', blames[1].args[1])
+    end)
+
+    it('dispatches pr subcommand to open_pr', function()
+      captured_gh_cmd({
+        args = 'pr 42',
+        fargs = { 'pr', '42' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local prs = calls_to('open_pr')
+      assert.equals(1, #prs)
+      assert.equals('42', prs[1].args[1])
+    end)
+
+    it('dispatches repo subcommand to open_repo', function()
+      captured_gh_cmd({
+        args = 'repo issues',
+        fargs = { 'repo', 'issues' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local repos = calls_to('open_repo')
+      assert.equals(1, #repos)
+      assert.equals('issues', repos[1].args[1])
+    end)
+
+    it('falls back to commit detection for unknown subcommand', function()
+      is_commit_return = true
+
+      captured_gh_cmd({
+        args = 'abc123def',
+        fargs = { 'abc123def' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local commits = calls_to('open_commit')
+      assert.equals(1, #commits)
+      assert.equals('abc123def', commits[1].args[1])
+    end)
+
+    it('falls back to open_pr for unknown non-commit subcommand', function()
+      is_commit_return = false
+
+      captured_gh_cmd({
+        args = 'some-query',
+        fargs = { 'some-query' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local prs = calls_to('open_pr')
+      assert.equals(1, #prs)
+      assert.equals('some-query', prs[1].args[1])
+    end)
+
+    it('blame includes line range with range opts', function()
+      helpers.expand_result = 'lua/init.lua'
+
+      captured_gh_cmd({
+        args = 'blame',
+        fargs = { 'blame' },
+        bang = false,
+        range = 2,
+        line1 = 5,
+        line2 = 10,
+      })
+
+      local blames = calls_to('open_blame')
+      assert.equals(1, #blames)
+      assert.equals('lua/init.lua#L5-L10', blames[1].args[1])
+    end)
+
+    it('browse includes line range with range opts', function()
+      helpers.expand_result = 'lua/init.lua'
+
+      captured_gh_cmd({
+        args = 'browse',
+        fargs = { 'browse' },
+        bang = false,
+        range = 2,
+        line1 = 5,
+        line2 = 10,
+      })
+
+      local files = calls_to('open_file')
+      assert.equals(1, #files)
+      assert.equals('lua/init.lua:5-10', files[1].args[1])
+    end)
+
+    it('passes bang flag through to handler', function()
+      is_commit_return = true
+      helpers.expand_result = 'abc123'
+
+      captured_gh_cmd({
+        args = '',
+        fargs = {},
+        bang = true,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local commits = calls_to('open_commit')
+      assert.equals(1, #commits)
+      assert.is_true(commits[1].args[2])
+    end)
+
+    it('passes bang flag through to subcommand', function()
+      helpers.expand_result = 'file.lua'
+
+      captured_gh_cmd({
+        args = 'browse',
+        fargs = { 'browse' },
+        bang = true,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local files = calls_to('open_file')
+      assert.equals(1, #files)
+      assert.is_true(files[1].args[2])
+    end)
+  end)
+
+  describe('completion', function()
+    it('returns all subcommands for bare GH', function()
+      local result = captured_complete('', 'GH ', 3)
+
+      assert.is_not_nil(result)
+      table.sort(result)
+      assert.same({ 'blame', 'browse', 'pr', 'repo' }, result)
+    end)
+
+    it('filters subcommands by prefix', function()
+      local result = captured_complete('b', 'GH b', 4)
+
+      assert.is_not_nil(result)
+      table.sort(result)
+      assert.same({ 'blame', 'browse' }, result)
+    end)
+
+    it('completes repo sub-arguments', function()
+      local result = captured_complete('wi', 'GH repo wi', 10)
+
+      assert.is_not_nil(result)
+      assert.same({ 'wikis' }, result)
+    end)
+
+    it('returns all subcommands with visual range prefix', function()
+      local result = captured_complete('', "'<,'>GH ", 8)
+
+      assert.is_not_nil(result)
+      table.sort(result)
+      assert.same({ 'blame', 'browse', 'pr', 'repo' }, result)
+    end)
+
+    it('returns all subcommands with bang', function()
+      local result = captured_complete('', 'GH! ', 4)
+
+      assert.is_not_nil(result)
+      table.sort(result)
+      assert.same({ 'blame', 'browse', 'pr', 'repo' }, result)
+    end)
+
+    it('returns nil for subcommand without completer', function()
+      local result = captured_complete('', 'GH browse ', 10)
+
+      assert.is_nil(result)
+    end)
+  end)
+end)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,21 @@
+local plenary_dir = os.getenv('PLENARY_DIR') or '/tmp/plenary.nvim'
+
+if vim.fn.isdirectory(plenary_dir) == 0 then
+  vim.fn.system({
+    'git',
+    'clone',
+    '--depth',
+    '1',
+    'https://github.com/nvim-lua/plenary.nvim',
+    plenary_dir,
+  })
+end
+
+vim.opt.rtp:append('.')
+vim.opt.rtp:append(plenary_dir)
+
+-- Allow spec files to require('helpers')
+package.path = './tests/?.lua;' .. package.path
+
+vim.cmd('runtime plugin/plenary.vim')
+require('plenary.busted')

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -1,0 +1,227 @@
+local helpers = require('helpers')
+
+describe('gh-navigator.utils', function()
+  local utils
+
+  before_each(function()
+    helpers.setup_mocks()
+    package.loaded['gh-navigator.utils'] = nil
+    utils = require('gh-navigator.utils')
+  end)
+
+  after_each(function()
+    helpers.teardown_mocks()
+    package.loaded['gh-navigator.utils'] = nil
+  end)
+
+  describe('gh_cli_installed', function()
+    it('returns true when gh is executable', function()
+      vim.fn.executable = function(_)
+        return 1
+      end
+
+      assert.is_true(utils.gh_cli_installed())
+    end)
+
+    it('returns false and notifies when gh is not executable', function()
+      vim.fn.executable = function(_)
+        return 0
+      end
+
+      assert.is_false(utils.gh_cli_installed())
+      assert.equals(1, #helpers.notifications)
+      assert.truthy(helpers.notifications[1].msg:find('GitHub CLI'))
+    end)
+  end)
+
+  describe('in_github_repo', function()
+    it('returns true for non-empty system output', function()
+      helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')
+
+      assert.is_true(utils.in_github_repo())
+    end)
+
+    it('returns false and notifies for empty system output', function()
+      -- default mock returns '' when no pattern matches
+      assert.is_false(utils.in_github_repo())
+      assert.equals(1, #helpers.notifications)
+      assert.truthy(helpers.notifications[1].msg:find('GitHub repository'))
+    end)
+  end)
+
+  describe('is_commit', function()
+    it('returns true for clean rev-parse output', function()
+      helpers.set_system_response('git rev-parse', 'abc123def456\n')
+
+      assert.is_true(utils.is_commit('abc123def456'))
+    end)
+
+    it('returns false when output contains fatal', function()
+      helpers.set_system_response('git rev-parse', 'fatal: Needed a single revision\n')
+
+      assert.is_false(utils.is_commit('not-a-commit'))
+    end)
+  end)
+
+  describe('open_blame', function()
+    before_each(function()
+      helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')
+      helpers.set_system_response('git branch', 'main\n')
+    end)
+
+    it('constructs blame URL and opens it', function()
+      utils.open_blame('lua/init.lua', false)
+
+      assert.equals('https://github.com/owner/repo/blame/main/lua/init.lua', helpers.opened_url)
+    end)
+
+    it('copies blame URL to clipboard with bang', function()
+      utils.open_blame('lua/init.lua', true)
+
+      assert.equals('+', helpers.last_register)
+      assert.equals('https://github.com/owner/repo/blame/main/lua/init.lua', helpers.last_register_value)
+    end)
+
+    it('includes line range fragment in URL', function()
+      utils.open_blame('lua/init.lua#L5-L10', false)
+
+      assert.equals('https://github.com/owner/repo/blame/main/lua/init.lua#L5-L10', helpers.opened_url)
+    end)
+  end)
+
+  describe('open_commit', function()
+    it('opens commit URL from gh browse', function()
+      helpers.set_system_response('gh browse', 'https://github.com/owner/repo/commit/abc123\n')
+
+      utils.open_commit('abc123', false)
+
+      assert.equals('https://github.com/owner/repo/commit/abc123', helpers.opened_url)
+    end)
+
+    it('copies commit URL to clipboard with bang', function()
+      helpers.set_system_response('gh browse', 'https://github.com/owner/repo/commit/abc123\n')
+
+      utils.open_commit('abc123', true)
+
+      assert.equals('+', helpers.last_register)
+      assert.equals('https://github.com/owner/repo/commit/abc123', helpers.last_register_value)
+    end)
+  end)
+
+  describe('open_file', function()
+    it('opens file URL from gh browse', function()
+      helpers.set_system_response('gh browse', 'https://github.com/owner/repo/blob/main/lua/init.lua\n')
+
+      utils.open_file('lua/init.lua', false)
+
+      assert.equals('https://github.com/owner/repo/blob/main/lua/init.lua', helpers.opened_url)
+    end)
+
+    it('copies file URL to clipboard with bang', function()
+      helpers.set_system_response('gh browse', 'https://github.com/owner/repo/blob/main/lua/init.lua\n')
+
+      utils.open_file('lua/init.lua', true)
+
+      assert.equals('+', helpers.last_register)
+      assert.equals('https://github.com/owner/repo/blob/main/lua/init.lua', helpers.last_register_value)
+    end)
+  end)
+
+  describe('open_pr', function()
+    it('opens PR by number', function()
+      helpers.set_system_response('gh pr view', '{"url":"https://github.com/owner/repo/pull/42"}')
+
+      utils.open_pr('42', false)
+
+      assert.equals('https://github.com/owner/repo/pull/42', helpers.opened_url)
+    end)
+
+    it('copies PR URL to clipboard with bang when numeric', function()
+      helpers.set_system_response('gh pr view', '{"url":"https://github.com/owner/repo/pull/42"}')
+
+      utils.open_pr('42', true)
+
+      assert.equals('+', helpers.last_register)
+      assert.equals('https://github.com/owner/repo/pull/42', helpers.last_register_value)
+    end)
+
+    it('opens single search result directly', function()
+      local results = vim.json.encode({
+        { number = 1, title = 'Fix bug', author = { name = 'Alice' }, url = 'https://github.com/owner/repo/pull/1' },
+      })
+      helpers.set_system_response('gh pr list', results)
+
+      utils.open_pr('fix bug', false)
+
+      assert.equals('https://github.com/owner/repo/pull/1', helpers.opened_url)
+    end)
+
+    it('presents vim.ui.select for multiple search results', function()
+      local results = vim.json.encode({
+        { number = 1, title = 'Fix bug A', author = { name = 'Alice' }, url = 'https://github.com/owner/repo/pull/1' },
+        { number = 2, title = 'Fix bug B', author = { name = 'Bob' }, url = 'https://github.com/owner/repo/pull/2' },
+      })
+      helpers.set_system_response('gh pr list', results)
+
+      utils.open_pr('fix bug', false)
+
+      assert.equals(2, #helpers.select_items)
+      -- auto-selects first item
+      assert.equals('https://github.com/owner/repo/pull/1', helpers.opened_url)
+    end)
+
+    it('notifies when no search results found', function()
+      helpers.set_system_response('gh pr list', '[]')
+
+      utils.open_pr('nonexistent', false)
+
+      assert.equals(1, #helpers.notifications)
+      assert.truthy(helpers.notifications[1].msg:find('No PR found'))
+    end)
+
+    it('notifies when PR number not found (Could not resolve)', function()
+      helpers.set_system_response('gh pr view', 'Could not resolve to a PullRequest')
+
+      utils.open_pr('999', false)
+
+      assert.equals(1, #helpers.notifications)
+      assert.truthy(helpers.notifications[1].msg:find('not found'))
+    end)
+  end)
+
+  describe('open_repo', function()
+    it('opens repo URL with path appended', function()
+      helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')
+
+      utils.open_repo('issues', false)
+
+      assert.equals('https://github.com/owner/repo/issues', helpers.opened_url)
+    end)
+
+    it('copies repo URL to clipboard with bang', function()
+      helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')
+
+      utils.open_repo('pulls', true)
+
+      assert.equals('+', helpers.last_register)
+      assert.equals('https://github.com/owner/repo/pulls', helpers.last_register_value)
+    end)
+
+    it('opens repo root with empty path', function()
+      helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')
+
+      utils.open_repo('', false)
+
+      assert.equals('https://github.com/owner/repo/', helpers.opened_url)
+    end)
+
+    it('notifies error when no git remotes found', function()
+      helpers.set_system_response('gh repo view', 'no git remotes found')
+
+      utils.open_repo('issues', false)
+
+      assert.equals(1, #helpers.notifications)
+      assert.truthy(helpers.notifications[1].msg:find('Not in a GitHub'))
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Add 45 plenary.nvim busted-style tests covering `utils.lua` (23 tests) and `init.lua` (22 tests)
- All tests mock `vim.fn.system` with pattern-matched responses — no real shell calls
- Add `Makefile` with `make test` and `make lint` targets
- Add CI `test` job (Neovim v0.10.0 + plenary) and extend stylua to also lint `tests/`

## Test plan
- [x] CI `test` job passes (all 45 specs green)
- [x] CI `stylua` job passes (now checks `lua/` and `tests/`)
- [x] CI `docs` job unaffected