### PR TITLE
feat: add GH compare subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ When called with no arguments, the word under the cursor is used instead.
 |--------------------|:---------------|
 | `GH blame` | Opens the current file in GitHub's blame view. |
 | `GH browse` | Opens the current file in GitHub's blob view. |
+| `GH compare` | Opens GitHub's compare view for the current branch against the default branch. |
 | `GH pr <arg>` | Opens a PR based on a commit SHA, PR number, or search term (e.g., `GH pr 1234`, `GH pr c2d25b3`, or `GH pr refactor the actor class`). |
 | `GH repo <path>` | Opens a certain path in the current repo on GitHub (e.g., `GH repo issues` opens the repo's issues page). Auto-completion is available for paths such as *issues, pulls, actions, releases*, etc.|
 

--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -54,6 +54,10 @@ function M.setup()
     utils.open_repo(arg, opts.bang)
   end
 
+  local function compare(_, opts)
+    utils.open_compare(opts.bang)
+  end
+
   local subcommand_tbl = {
     browse = {
       call = function(args, opts)
@@ -63,6 +67,11 @@ function M.setup()
     blame = {
       call = function(args, opts)
         blame(args, opts)
+      end,
+    },
+    compare = {
+      call = function(args, opts)
+        compare(args, opts)
       end,
     },
     pr = {

--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -81,6 +81,16 @@ local function open_pr_by_search(query, bang)
   end
 end
 
+function M.open_compare(bang)
+  local url = repo_url() .. '/compare/' .. current_branch()
+
+  if bang then
+    copy_to_clipboard(url)
+  else
+    vim.ui.open(url)
+  end
+end
+
 function M.open_blame(filename, bang)
   local url = blame_url(filename)
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -39,6 +39,9 @@ describe('gh-navigator', function()
     utils.open_repo = function(path, bang)
       table.insert(spy_calls, { fn = 'open_repo', args = { path, bang } })
     end
+    utils.open_compare = function(bang)
+      table.insert(spy_calls, { fn = 'open_compare', args = { bang } })
+    end
 
     -- Capture the command callback and completion function
     local orig_create = vim.api.nvim_create_user_command
@@ -222,6 +225,21 @@ describe('gh-navigator', function()
       assert.equals('42', prs[1].args[1])
     end)
 
+    it('dispatches compare subcommand to open_compare', function()
+      captured_gh_cmd({
+        args = 'compare',
+        fargs = { 'compare' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local compares = calls_to('open_compare')
+      assert.equals(1, #compares)
+      assert.is_false(compares[1].args[1])
+    end)
+
     it('dispatches repo subcommand to open_repo', function()
       captured_gh_cmd({
         args = 'repo issues',
@@ -347,7 +365,7 @@ describe('gh-navigator', function()
 
       assert.is_not_nil(result)
       table.sort(result)
-      assert.same({ 'blame', 'browse', 'pr', 'repo' }, result)
+      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo' }, result)
     end)
 
     it('filters subcommands by prefix', function()
@@ -370,7 +388,7 @@ describe('gh-navigator', function()
 
       assert.is_not_nil(result)
       table.sort(result)
-      assert.same({ 'blame', 'browse', 'pr', 'repo' }, result)
+      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo' }, result)
     end)
 
     it('returns all subcommands with bang', function()
@@ -378,7 +396,7 @@ describe('gh-navigator', function()
 
       assert.is_not_nil(result)
       table.sort(result)
-      assert.same({ 'blame', 'browse', 'pr', 'repo' }, result)
+      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo' }, result)
     end)
 
     it('returns nil for subcommand without completer', function()

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -63,6 +63,26 @@ describe('gh-navigator.utils', function()
     end)
   end)
 
+  describe('open_compare', function()
+    before_each(function()
+      helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')
+      helpers.set_system_response('git branch', 'feature-branch\n')
+    end)
+
+    it('constructs compare URL and opens it', function()
+      utils.open_compare(false)
+
+      assert.equals('https://github.com/owner/repo/compare/feature-branch', helpers.opened_url)
+    end)
+
+    it('copies compare URL to clipboard with bang', function()
+      utils.open_compare(true)
+
+      assert.equals('+', helpers.last_register)
+      assert.equals('https://github.com/owner/repo/compare/feature-branch', helpers.last_register_value)
+    end)
+  end)
+
   describe('open_blame', function()
     before_each(function()
       helpers.set_system_response('gh repo view', '{"url":"https://github.com/owner/repo"}')


### PR DESCRIPTION
## Summary
- Adds a `GH compare` subcommand that opens GitHub's compare view for the current branch against the default branch
- Supports `GH! compare` to copy the URL to clipboard instead of opening
- Includes tests for both `open_compare` in utils and command dispatch in init

## Test plan
- [x] `make test` — all 48 tests pass (25 utils, 23 init)
- [ ] Manual: run `GH compare` on a feature branch and confirm it opens the correct compare page
- [ ] Manual: run `GH! compare` and confirm the URL is copied to clipboard