### PR TITLE
fix: silence error notification when not in a GitHub repo

### DIFF
--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -168,7 +168,6 @@ end
 
 function M.in_github_repo()
   if vim.fn.system('gh repo view --json url 2>/dev/null') == '' then
-    vim.notify('gh-navigator expects to be in a GitHub repository', vim.log.ERROR, { title = 'gh-navigator' })
     return false
   else
     return true

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -41,11 +41,10 @@ describe('gh-navigator.utils', function()
       assert.is_true(utils.in_github_repo())
     end)
 
-    it('returns false and notifies for empty system output', function()
+    it('returns false silently for empty system output', function()
       -- default mock returns '' when no pattern matches
       assert.is_false(utils.in_github_repo())
-      assert.equals(1, #helpers.notifications)
-      assert.truthy(helpers.notifications[1].msg:find('GitHub repository'))
+      assert.equals(0, #helpers.notifications)
     end)
   end)
 


### PR DESCRIPTION
## Summary
- Removes the `vim.notify` error when the plugin is loaded outside a GitHub repository
- The plugin silently skips setup instead, since not being in a repo is a normal use case

## Test plan
- [x] Updated test to assert zero notifications when not in a GitHub repo
- [x] All 48 tests pass