### PR TITLE
feat: derive git repo from current buffer instead of CWD

### DIFF
--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -7,14 +7,15 @@ function M.setup()
     return
   end
 
-  if not utils.in_github_repo() then
-    return
-  end
-
   local function blame(args, opts)
     local filename = args[1] or ''
     if filename == '' then
-      filename = vim.fn.expand('%:.')
+      local dir = utils.buf_repo_dir()
+      if not dir then
+        vim.notify('Not in a Git repository', vim.log.levels.ERROR, { title = 'gh-navigator' })
+        return
+      end
+      filename = utils.buf_relative_path(dir)
     end
 
     if opts.range == 0 then
@@ -28,7 +29,12 @@ function M.setup()
   local function browse(args, opts)
     local filename = args[1] or ''
     if filename == '' then
-      filename = vim.fn.expand('%:.')
+      local dir = utils.buf_repo_dir()
+      if not dir then
+        vim.notify('Not in a Git repository', vim.log.levels.ERROR, { title = 'gh-navigator' })
+        return
+      end
+      filename = utils.buf_relative_path(dir)
     end
 
     if opts.range == 0 then

--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -12,7 +12,7 @@ function M.setup()
     if filename == '' then
       local dir = utils.buf_repo_dir()
       if not dir then
-        vim.notify('Not in a Git repository', vim.log.levels.ERROR, { title = 'gh-navigator' })
+        utils.not_in_repo_notify()
         return
       end
       filename = utils.buf_relative_path(dir)
@@ -31,7 +31,7 @@ function M.setup()
     if filename == '' then
       local dir = utils.buf_repo_dir()
       if not dir then
-        vim.notify('Not in a Git repository', vim.log.levels.ERROR, { title = 'gh-navigator' })
+        utils.not_in_repo_notify()
         return
       end
       filename = utils.buf_relative_path(dir)

--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -9,19 +9,19 @@ function M.setup()
 
   local function buf_filename(args)
     local filename = args[1] or ''
+    local dir = utils.buf_repo_dir()
     if filename == '' then
-      local dir = utils.buf_repo_dir()
       if not dir then
         utils.not_in_repo_notify()
-        return nil
+        return nil, nil
       end
       filename = utils.buf_relative_path(dir)
     end
-    return filename
+    return filename, dir
   end
 
   local function blame(args, opts)
-    local filename = buf_filename(args)
+    local filename, dir = buf_filename(args)
     if not filename then
       return
     end
@@ -29,11 +29,11 @@ function M.setup()
     if opts.range ~= 0 then
       filename = filename .. '#' .. 'L' .. opts.line1 .. '-' .. 'L' .. opts.line2
     end
-    utils.open_blame(filename, opts.bang)
+    utils.open_blame(filename, opts.bang, dir)
   end
 
   local function browse(args, opts)
-    local filename = buf_filename(args)
+    local filename, dir = buf_filename(args)
     if not filename then
       return
     end
@@ -41,7 +41,7 @@ function M.setup()
     if opts.range ~= 0 then
       filename = filename .. ':' .. opts.line1 .. '-' .. opts.line2
     end
-    utils.open_file(filename, opts.bang)
+    utils.open_file(filename, opts.bang, dir)
   end
 
   local function pr(args, opts)
@@ -111,6 +111,19 @@ function M.setup()
     },
   }
 
+  local function resolve_commit_or_pr(arg, bang)
+    local dir = utils.buf_repo_dir()
+    if not dir then
+      return utils.not_in_repo_notify()
+    end
+
+    if utils.is_commit(arg, dir) then
+      utils.open_commit(arg, bang, dir)
+    else
+      utils.open_pr(arg, bang, dir)
+    end
+  end
+
   local function gh_cmd(opts)
     local fargs = opts.fargs
 
@@ -121,22 +134,13 @@ function M.setup()
         arg = vim.fn.expand('<cword>')
       end
 
-      if utils.is_commit(arg) then
-        utils.open_commit(arg, opts.bang)
-      else
-        utils.open_pr(arg, opts.bang)
-      end
+      resolve_commit_or_pr(arg, opts.bang)
     else
       local subcommand_key = fargs[1]
       local args = #fargs > 1 and vim.list_slice(fargs, 2, #fargs) or {}
       local subcommand = subcommand_tbl[subcommand_key]
       if not subcommand then
-        local arg = opts.args
-        if utils.is_commit(arg) then
-          utils.open_commit(arg, opts.bang)
-        else
-          utils.open_pr(arg, opts.bang)
-        end
+        resolve_commit_or_pr(opts.args, opts.bang)
         return
       end
       subcommand.call(args, opts)

--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -7,42 +7,41 @@ function M.setup()
     return
   end
 
-  local function blame(args, opts)
+  local function buf_filename(args)
     local filename = args[1] or ''
     if filename == '' then
       local dir = utils.buf_repo_dir()
       if not dir then
         utils.not_in_repo_notify()
-        return
+        return nil
       end
       filename = utils.buf_relative_path(dir)
     end
+    return filename
+  end
 
-    if opts.range == 0 then
-      utils.open_blame(filename, opts.bang)
-    else
-      filename = filename .. '#' .. 'L' .. opts.line1 .. '-' .. 'L' .. opts.line2
-      utils.open_blame(filename, opts.bang)
+  local function blame(args, opts)
+    local filename = buf_filename(args)
+    if not filename then
+      return
     end
+
+    if opts.range ~= 0 then
+      filename = filename .. '#' .. 'L' .. opts.line1 .. '-' .. 'L' .. opts.line2
+    end
+    utils.open_blame(filename, opts.bang)
   end
 
   local function browse(args, opts)
-    local filename = args[1] or ''
-    if filename == '' then
-      local dir = utils.buf_repo_dir()
-      if not dir then
-        utils.not_in_repo_notify()
-        return
-      end
-      filename = utils.buf_relative_path(dir)
+    local filename = buf_filename(args)
+    if not filename then
+      return
     end
 
-    if opts.range == 0 then
-      utils.open_file(filename, opts.bang)
-    else
+    if opts.range ~= 0 then
       filename = filename .. ':' .. opts.line1 .. '-' .. opts.line2
-      utils.open_file(filename, opts.bang)
     end
+    utils.open_file(filename, opts.bang)
   end
 
   local function pr(args, opts)

--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -122,8 +122,8 @@ function M.buf_relative_path(repo_dir)
   return abs_path
 end
 
-function M.open_compare(bang)
-  local dir = M.buf_repo_dir()
+function M.open_compare(bang, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return M.not_in_repo_notify()
   end
@@ -132,8 +132,8 @@ function M.open_compare(bang)
   open_or_copy(url, bang)
 end
 
-function M.open_blame(filename, bang)
-  local dir = M.buf_repo_dir()
+function M.open_blame(filename, bang, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return M.not_in_repo_notify()
   end
@@ -142,8 +142,8 @@ function M.open_blame(filename, bang)
   open_or_copy(url, bang)
 end
 
-function M.open_commit(sha, bang)
-  local dir = M.buf_repo_dir()
+function M.open_commit(sha, bang, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return M.not_in_repo_notify()
   end
@@ -153,8 +153,8 @@ function M.open_commit(sha, bang)
   open_or_copy(url, bang)
 end
 
-function M.open_file(filename, bang)
-  local dir = M.buf_repo_dir()
+function M.open_file(filename, bang, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return M.not_in_repo_notify()
   end
@@ -164,8 +164,8 @@ function M.open_file(filename, bang)
   open_or_copy(url, bang)
 end
 
-function M.open_pr(number_or_query, bang)
-  local dir = M.buf_repo_dir()
+function M.open_pr(number_or_query, bang, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return M.not_in_repo_notify()
   end
@@ -177,8 +177,8 @@ function M.open_pr(number_or_query, bang)
   end
 end
 
-function M.open_repo(path, bang)
-  local dir = M.buf_repo_dir()
+function M.open_repo(path, bang, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return M.not_in_repo_notify()
   end
@@ -187,14 +187,14 @@ function M.open_repo(path, bang)
   local result = vim.fn.system(cmd)
 
   if not string.find(result, 'no git remotes found') then
-    open_or_copy(repo_url(dir) .. '/' .. path, bang)
+    open_or_copy(vim.json.decode(result).url .. '/' .. path, bang)
   else
     vim.notify('Not in a GitHub hosted repository', vim.log.ERROR, { title = 'gh-navigator' })
   end
 end
 
-function M.is_commit(arg)
-  local dir = M.buf_repo_dir()
+function M.is_commit(arg, dir)
+  dir = dir or M.buf_repo_dir()
   if not dir then
     return false
   end

--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -9,6 +9,14 @@ local function copy_to_clipboard(url)
   vim.notify('Copied to clipboard: ' .. url, vim.log.levels.INFO, { title = 'gh-navigator' })
 end
 
+local function open_or_copy(url, bang)
+  if bang then
+    copy_to_clipboard(url)
+  else
+    vim.ui.open(url)
+  end
+end
+
 local function git_cmd(dir, args)
   if dir then
     return 'git -C ' .. vim.fn.shellescape(dir) .. ' ' .. args
@@ -57,11 +65,7 @@ local function ui_select_pr(prs, bang)
     end,
   }, function(choice)
     if choice ~= nil then
-      if bang then
-        return copy_to_clipboard(choice.url)
-      else
-        return vim.ui.open(choice.url)
-      end
+      open_or_copy(choice.url, bang)
     end
   end)
 end
@@ -71,12 +75,7 @@ local function open_pr_by_number(number, bang, dir)
   local result = vim.fn.system(cmd)
 
   if not string.find(result, 'Could not resolve') then
-    local url = vim.json.decode(result).url
-    if bang then
-      copy_to_clipboard(url)
-    else
-      vim.ui.open(url)
-    end
+    open_or_copy(vim.json.decode(result).url, bang)
   else
     vim.notify('PR #' .. number .. ' not found', vim.log.INFO, { title = 'GHPR' })
   end
@@ -87,11 +86,7 @@ local function open_pr_by_search(query, bang, dir)
   local results = vim.json.decode(vim.fn.system(cmd))
 
   if vim.tbl_count(results) == 1 then
-    if bang then
-      copy_to_clipboard(results[1].url)
-    else
-      vim.ui.open(results[1].url)
-    end
+    open_or_copy(results[1].url, bang)
   elseif vim.tbl_count(results) > 1 then
     ui_select_pr(results, bang)
   else
@@ -134,12 +129,7 @@ function M.open_compare(bang)
   end
 
   local url = repo_url(dir) .. '/compare/' .. current_branch(dir)
-
-  if bang then
-    copy_to_clipboard(url)
-  else
-    vim.ui.open(url)
-  end
+  open_or_copy(url, bang)
 end
 
 function M.open_blame(filename, bang)
@@ -149,12 +139,7 @@ function M.open_blame(filename, bang)
   end
 
   local url = blame_url(filename, dir)
-
-  if bang then
-    copy_to_clipboard(url)
-  else
-    vim.ui.open(url)
-  end
+  open_or_copy(url, bang)
 end
 
 function M.open_commit(sha, bang)
@@ -165,12 +150,7 @@ function M.open_commit(sha, bang)
 
   local cmd = gh_cmd(dir, 'browse ' .. sha .. ' -n')
   local url = vim.trim(vim.fn.system(cmd))
-
-  if bang then
-    copy_to_clipboard(url)
-  else
-    vim.ui.open(url)
-  end
+  open_or_copy(url, bang)
 end
 
 function M.open_file(filename, bang)
@@ -181,12 +161,7 @@ function M.open_file(filename, bang)
 
   local cmd = gh_cmd(dir, 'browse ' .. filename .. ' -n')
   local url = vim.trim(vim.fn.system(cmd))
-
-  if bang then
-    copy_to_clipboard(url)
-  else
-    vim.ui.open(url)
-  end
+  open_or_copy(url, bang)
 end
 
 function M.open_pr(number_or_query, bang)
@@ -212,12 +187,7 @@ function M.open_repo(path, bang)
   local result = vim.fn.system(cmd)
 
   if not string.find(result, 'no git remotes found') then
-    local url = repo_url(dir) .. '/' .. path
-    if bang then
-      copy_to_clipboard(url)
-    else
-      vim.ui.open(url)
-    end
+    open_or_copy(repo_url(dir) .. '/' .. path, bang)
   else
     vim.notify('Not in a GitHub hosted repository', vim.log.ERROR, { title = 'gh-navigator' })
   end

--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -38,7 +38,7 @@ local function blame_url(filename, dir)
   return repo_url(dir) .. '/blame/' .. current_branch(dir) .. '/' .. filename
 end
 
-local function not_in_repo_notify()
+function M.not_in_repo_notify()
   vim.notify('Not in a Git repository', vim.log.levels.ERROR, { title = 'gh-navigator' })
 end
 
@@ -130,7 +130,7 @@ end
 function M.open_compare(bang)
   local dir = M.buf_repo_dir()
   if not dir then
-    return not_in_repo_notify()
+    return M.not_in_repo_notify()
   end
 
   local url = repo_url(dir) .. '/compare/' .. current_branch(dir)
@@ -145,7 +145,7 @@ end
 function M.open_blame(filename, bang)
   local dir = M.buf_repo_dir()
   if not dir then
-    return not_in_repo_notify()
+    return M.not_in_repo_notify()
   end
 
   local url = blame_url(filename, dir)
@@ -160,7 +160,7 @@ end
 function M.open_commit(sha, bang)
   local dir = M.buf_repo_dir()
   if not dir then
-    return not_in_repo_notify()
+    return M.not_in_repo_notify()
   end
 
   local cmd = gh_cmd(dir, 'browse ' .. sha .. ' -n')
@@ -176,7 +176,7 @@ end
 function M.open_file(filename, bang)
   local dir = M.buf_repo_dir()
   if not dir then
-    return not_in_repo_notify()
+    return M.not_in_repo_notify()
   end
 
   local cmd = gh_cmd(dir, 'browse ' .. filename .. ' -n')
@@ -192,7 +192,7 @@ end
 function M.open_pr(number_or_query, bang)
   local dir = M.buf_repo_dir()
   if not dir then
-    return not_in_repo_notify()
+    return M.not_in_repo_notify()
   end
 
   if tonumber(number_or_query) then
@@ -205,7 +205,7 @@ end
 function M.open_repo(path, bang)
   local dir = M.buf_repo_dir()
   if not dir then
-    return not_in_repo_notify()
+    return M.not_in_repo_notify()
   end
 
   local cmd = gh_cmd(dir, 'repo view --json url')

--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -97,6 +97,19 @@ end
 function M.buf_repo_dir()
   local buf_dir = vim.fn.expand('%:p:h')
   if buf_dir == '' then
+    -- Current buffer has no file (e.g., floating/scratch buffer).
+    -- Fall back to the first normal window's buffer.
+    for _, win in ipairs(vim.api.nvim_list_wins()) do
+      if vim.api.nvim_win_get_config(win).relative == '' then
+        local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(win))
+        if name ~= '' then
+          buf_dir = vim.fn.fnamemodify(name, ':h')
+          break
+        end
+      end
+    end
+  end
+  if buf_dir == '' then
     return nil
   end
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -17,8 +17,11 @@ describe('gh-navigator', function()
     utils.gh_cli_installed = function()
       return true
     end
-    utils.in_github_repo = function()
-      return true
+    utils.buf_repo_dir = function()
+      return '/mock/repo'
+    end
+    utils.buf_relative_path = function(_)
+      return helpers.expand_result or 'current_file.lua'
     end
     utils.is_commit = function(arg)
       table.insert(spy_calls, { fn = 'is_commit', args = { arg } })
@@ -86,29 +89,6 @@ describe('gh-navigator', function()
 
       local utils = require('gh-navigator.utils')
       utils.gh_cli_installed = function()
-        return false
-      end
-      utils.in_github_repo = function()
-        return true
-      end
-
-      require('gh-navigator').setup()
-
-      assert.equals(0, vim.fn.exists(':GH'))
-    end)
-
-    it('does not create GH command when not in github repo', function()
-      pcall(vim.api.nvim_del_user_command, 'GH')
-
-      package.loaded['gh-navigator'] = nil
-      package.loaded['gh-navigator.init'] = nil
-      package.loaded['gh-navigator.utils'] = nil
-
-      local utils = require('gh-navigator.utils')
-      utils.gh_cli_installed = function()
-        return true
-      end
-      utils.in_github_repo = function()
         return false
       end
 


### PR DESCRIPTION
## Summary
- Derives the repo directory from the **current buffer's file path** (`git rev-parse --show-toplevel`) instead of relying on Neovim's CWD
- Passes repo dir to all CLI calls: `git -C <dir>` for git commands, `cd <dir> && gh` for gh commands (gh CLI doesn't support `-C`)
- Removes the `in_github_repo()` setup-time guard — the `GH` command now always registers and each subcommand checks the buffer's repo context individually
- Adds `buf_repo_dir()` and `buf_relative_path()` public utilities

## Test plan
- [x] `make test` — all 52 tests pass (30 utils + 22 init)
- [x] Open Neovim at a parent folder (e.g. `~/Code`), edit a file in a child repo, run `GH blame` / `GH browse` / `GH compare`
- [x] Open Neovim directly in a repo and verify existing behavior is unchanged
- [x] Open a buffer with no file (e.g. `:enew`) and run a `GH` command — should get "Not in a Git repository" notification