### PR TITLE
refactor: use vim.system for shell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This Neovim plugin makes jumping from coding to GitHub as painless as possible.
 
 ### Prerequisites
 
-The plugin primarily acts as a wrapper for the [GitHub CLI](https://cli.github.com/) (`gh`), and also makes a few direct `git` calls. So ensure the `gh` tool is installed and can connect to your GitHub account. 
+- **Neovim 0.10+** is required (for `vim.system`).
+
+The plugin primarily acts as a wrapper for the [GitHub CLI](https://cli.github.com/) (`gh`), and also makes a few direct `git` calls. So ensure the `gh` tool is installed and can connect to your GitHub account.
 
 Here are instructions for macOS users:
 

--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -76,7 +76,8 @@ local function open_pr_by_number(number, bang, dir)
 end
 
 local function open_pr_by_search(query, bang, dir)
-  local result = run_gh(dir, { 'pr', 'list', '--search', query, '--state', 'merged', '--json', 'number,title,author,url' })
+  local result =
+    run_gh(dir, { 'pr', 'list', '--search', query, '--state', 'merged', '--json', 'number,title,author,url' })
   local results = vim.json.decode(result.stdout)
 
   if vim.tbl_count(results) == 1 then


### PR DESCRIPTION
## Summary

- Replace all `vim.fn.system(string)` calls with `vim.system(list, {cwd=dir}):wait()`, eliminating shell interpolation and the potential for injection
- Remove `git_cmd`/`gh_cmd` string builders, `shellescape` usage, and `vim.v.shell_error` checks in favor of list-based args, `cwd` option, and `result.code`
- Update test mocks to match the new `vim.system` API
- Document Neovim 0.10+ as a requirement in the README

## Test plan

- [x] All 55 existing tests pass (`make test`)
- [x] Manual: run `:GH browse`, `:GH blame`, `:GH compare`, `:GH repo issues` from various buffers
- [x] Manual: test from a float window and from a buffer outside the repo