### PR TITLE
feat: add agents to GH repo completion paths

### DIFF
--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -91,6 +91,7 @@ function M.setup()
       complete = function(subcmd_arg_lead)
         local repo_args = {
           'actions',
+          'agents',
           'discussions',
           'issues',
           'projects',


### PR DESCRIPTION
## Summary

- Add `agents` to the `GH repo` autocomplete list, matching the new `/agents` URL path on GitHub repos (e.g., https://github.com/planningcenter/giving/agents)

## Test plan

- [x] All 55 tests pass
- [ ] Manual: `:GH repo agents` opens the agents page
- [ ] Manual: `:GH repo ag<Tab>` completes to `agents`