### PR TITLE
docs: simplify gh CLI setup code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,8 @@ Open GitHub URLs for files, blame, commits, PRs, and repos directly from any Neo
 - **[GitHub CLI](https://cli.github.com/)** (`gh`) — installed and authenticated
 
 ```shell
-# Install (see https://github.com/cli/cli#installation for other platforms)
 brew install gh
-
-# Authenticate
 gh auth login
-
-# Verify
-gh auth status
 ```
 
 ### Installation


### PR DESCRIPTION
## Summary
- Remove comments and `gh auth status` from the prerequisites code block
- The prerequisite text already links to cli.github.com and explains what's needed
- Eliminates horizontal scrollbar on the code block

## Test plan
- [ ] Verify README renders correctly on GitHub