### PR TITLE
fix: prevent commit shas from being parsed as PR numbers

### DIFF
--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -186,7 +186,7 @@ function M.open_pr(number_or_query, bang, dir)
     return M.not_in_repo_notify()
   end
 
-  if tonumber(number_or_query) then
+  if number_or_query:match('^%d+$') then
     open_pr_by_number(number_or_query, bang, dir)
   else
     open_pr_by_search(number_or_query, bang, dir)

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -358,6 +358,17 @@ describe('gh-navigator.utils', function()
       assert.equals(1, #helpers.notifications)
       assert.truthy(helpers.notifications[1].msg:find('not found'))
     end)
+
+    it('treats commit sha with scientific notation chars as search query', function()
+      local results = vim.json.encode({
+        { number = 1, title = 'Old commit', author = { name = 'Alice' }, url = 'https://github.com/owner/repo/pull/1' },
+      })
+      helpers.set_system_response('pr list', results)
+
+      utils.open_pr('36e54817', false)
+
+      assert.equals('https://github.com/owner/repo/pull/1', helpers.opened_url)
+    end)
   end)
 
   describe('open_repo', function()


### PR DESCRIPTION
## Summary

- Lua's `tonumber()` interprets commit shas containing `e` followed by digits as scientific notation (e.g., `36e54817` = 36×10^54817 = `inf`), causing `:GH pr` to route them to `open_pr_by_number` instead of `open_pr_by_search`
- Replace `tonumber(number_or_query)` with `number_or_query:match('^%d+$')` so only pure digit strings are treated as PR numbers
- Add test covering the edge case

## Test plan

- [x] All 56 tests pass (`make test`)
- [ ] Run `:GH pr` with cursor on a commit sha like `36e54817` — should search for associated PR instead of crashing
- [ ] Run `:GH pr 42` — should still look up PR #42 by number