### PR TITLE
fix: handle all gh pr view failure modes

### DIFF
--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -92,7 +92,7 @@ end
 local function open_pr_by_number(number, bang, dir)
   local result = run_gh(dir, { 'pr', 'view', tostring(number), '--json', 'url' })
 
-  if not string.find(result.stdout, 'Could not resolve') then
+  if result.code == 0 then
     open_or_copy(vim.json.decode(result.stdout).url, bang)
   else
     vim.notify('PR #' .. number .. ' not found', vim.log.levels.INFO, { title = 'GH Navigator' })

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -350,8 +350,8 @@ describe('gh-navigator.utils', function()
       assert.truthy(helpers.notifications[1].msg:find('No PR found'))
     end)
 
-    it('notifies when PR number not found (Could not resolve)', function()
-      helpers.set_system_response('pr view', 'Could not resolve to a PullRequest')
+    it('notifies when PR number not found', function()
+      helpers.set_system_response('pr view', '', 1)
 
       utils.open_pr('999', false)
 


### PR DESCRIPTION
## Summary

- Check `result.code` instead of scanning stdout for a specific error string
- When `gh` exits non-zero (e.g., PR number doesn't exist), stdout may be empty rather than containing `"Could not resolve"`, causing `vim.json.decode` to crash on empty input

## Test plan

- [x] All 56 tests pass (`make test`)
- [ ] Run `:GH pr` with cursor on a large numeric value (e.g., a line number in blame) — should show "not found" notification instead of crashing