### PR TITLE
feat: add GH sha subcommand for explicit commit lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The plugin provides a single `:GH` command with sub-commands. Tab completion is 
 | `GH browse` | Opens the current file in GitHub's blob view. |
 | `GH compare` | Opens GitHub's compare view for the current branch against the default branch. |
 | `GH pr <arg>` | Opens a PR by number or search term (e.g., `GH pr 1234` or `GH pr refactor the actor class`). |
+| `GH sha <ref>` | Opens a commit by SHA. Useful when a SHA is purely numeric and would otherwise be treated as a PR number. |
 | `GH repo <path>` | Opens a path in the current repo on GitHub (e.g., `GH repo issues`). Tab-completable paths include *issues*, *pulls*, *actions*, *releases*, etc. |
 
 > [!Note]

--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -53,6 +53,15 @@ function M.setup()
     utils.open_pr(arg, opts.bang)
   end
 
+  local function sha(args, opts)
+    local arg = args[1] or ''
+
+    if arg == '' then
+      arg = vim.fn.expand('<cword>')
+    end
+    utils.open_commit(arg, opts.bang)
+  end
+
   local function repo(args, opts)
     local arg = args and args[1] or ''
 
@@ -82,6 +91,11 @@ function M.setup()
     pr = {
       call = function(args, opts)
         pr(args, opts)
+      end,
+    },
+    sha = {
+      call = function(args, opts)
+        sha(args, opts)
       end,
     },
     repo = {

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -205,6 +205,22 @@ describe('gh-navigator', function()
       assert.equals('42', prs[1].args[1])
     end)
 
+    it('dispatches sha subcommand to open_commit', function()
+      captured_gh_cmd({
+        args = 'sha abc123',
+        fargs = { 'sha', 'abc123' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local commits = calls_to('open_commit')
+      assert.equals(1, #commits)
+      assert.equals('abc123', commits[1].args[1])
+      assert.is_false(commits[1].args[2])
+    end)
+
     it('dispatches compare subcommand to open_compare', function()
       captured_gh_cmd({
         args = 'compare',
@@ -345,7 +361,7 @@ describe('gh-navigator', function()
 
       assert.is_not_nil(result)
       table.sort(result)
-      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo' }, result)
+      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo', 'sha' }, result)
     end)
 
     it('filters subcommands by prefix', function()
@@ -368,7 +384,7 @@ describe('gh-navigator', function()
 
       assert.is_not_nil(result)
       table.sort(result)
-      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo' }, result)
+      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo', 'sha' }, result)
     end)
 
     it('returns all subcommands with bang', function()
@@ -376,7 +392,7 @@ describe('gh-navigator', function()
 
       assert.is_not_nil(result)
       table.sort(result)
-      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo' }, result)
+      assert.same({ 'blame', 'browse', 'compare', 'pr', 'repo', 'sha' }, result)
     end)
 
     it('returns nil for subcommand without completer', function()


### PR DESCRIPTION
## Summary
- Adds `:GH sha <ref>` subcommand that always opens the given ref as a commit, bypassing PR detection
- Useful when a commit SHA is purely numeric and would otherwise be interpreted as a PR number
- Supports `<cword>` fallback when no argument is given, and bang (`!`) for clipboard copy

## Test plan
- [x] New dispatch test for `GH sha abc123` verifies `open_commit` is called with correct args
- [x] Updated completion tests to include `sha` in subcommand list
- [x] All 57 tests pass (34 utils + 23 init)