### PR TITLE
fix: construct commit URL directly instead of using gh browse

### DIFF
--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -188,8 +188,7 @@ function M.open_commit(sha, bang, dir)
     return M.not_in_repo_notify()
   end
 
-  local result = run_gh(dir, { 'browse', sha, '-n' })
-  local url = vim.trim(result.stdout)
+  local url = repo_url(dir) .. '/commit/' .. sha
   open_or_copy(url, bang)
 end
 

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -253,23 +253,28 @@ describe('gh-navigator.utils', function()
   end)
 
   describe('open_commit', function()
-    it('opens commit URL from gh browse', function()
+    before_each(function()
       mock_buf_repo('/mock/repo')
-      helpers.set_system_response('browse', 'https://github.com/owner/repo/commit/abc123\n')
+      helpers.set_system_response('repo view', '{"url":"https://github.com/owner/repo"}')
+    end)
 
+    it('constructs commit URL and opens it', function()
       utils.open_commit('abc123', false)
 
       assert.equals('https://github.com/owner/repo/commit/abc123', helpers.opened_url)
     end)
 
     it('copies commit URL to clipboard with bang', function()
-      mock_buf_repo('/mock/repo')
-      helpers.set_system_response('browse', 'https://github.com/owner/repo/commit/abc123\n')
-
       utils.open_commit('abc123', true)
 
       assert.equals('+', helpers.last_register)
       assert.equals('https://github.com/owner/repo/commit/abc123', helpers.last_register_value)
+    end)
+
+    it('handles purely numeric sha without treating it as an issue', function()
+      utils.open_commit('36234615', false)
+
+      assert.equals('https://github.com/owner/repo/commit/36234615', helpers.opened_url)
     end)
   end)
 


### PR DESCRIPTION
## Summary
- `gh browse <arg> -n` treats purely numeric arguments as issue numbers, so `GH sha 36234615` would open `/issues/36234615` instead of `/commit/36234615`
- Constructs the commit URL directly from `repo_url + '/commit/' + sha`, consistent with how `open_blame` and `open_compare` already work
- Adds a test for the purely numeric SHA case

## Test plan
- [x] Existing commit URL tests updated to use `repo view` mock instead of `gh browse`
- [x] New test: purely numeric SHA produces correct `/commit/` URL
- [x] All 58 tests pass (35 utils + 23 init)