### PR TITLE
fix: validate sha argument with rev-parse before opening commit URL

### DIFF
--- a/lua/gh-navigator/init.lua
+++ b/lua/gh-navigator/init.lua
@@ -59,6 +59,12 @@ function M.setup()
     if arg == '' then
       arg = vim.fn.expand('<cword>')
     end
+
+    if not utils.is_commit(arg) then
+      vim.notify('Not a valid commit: ' .. arg, vim.log.levels.WARN, { title = 'GH Navigator' })
+      return
+    end
+
     utils.open_commit(arg, opts.bang)
   end
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -206,6 +206,8 @@ describe('gh-navigator', function()
     end)
 
     it('dispatches sha subcommand to open_commit', function()
+      is_commit_return = true
+
       captured_gh_cmd({
         args = 'sha abc123',
         fargs = { 'sha', 'abc123' },
@@ -219,6 +221,24 @@ describe('gh-navigator', function()
       assert.equals(1, #commits)
       assert.equals('abc123', commits[1].args[1])
       assert.is_false(commits[1].args[2])
+    end)
+
+    it('sha subcommand notifies when argument is not a valid commit', function()
+      is_commit_return = false
+
+      captured_gh_cmd({
+        args = 'sha include',
+        fargs = { 'sha', 'include' },
+        bang = false,
+        range = 0,
+        line1 = 0,
+        line2 = 0,
+      })
+
+      local commits = calls_to('open_commit')
+      assert.equals(0, #commits)
+      assert.equals(1, #helpers.notifications)
+      assert.equals('Not a valid commit: include', helpers.notifications[1].msg)
     end)
 
     it('dispatches compare subcommand to open_compare', function()


### PR DESCRIPTION
## Summary
- `GH sha` on a non-commit word (e.g. cursor on `include`) would open a bogus `/commit/include` URL
- Now validates via `is_commit` (`git rev-parse --verify`) and shows a warning if the argument isn't a valid commit ref

## Test plan
- [x] New test: invalid argument shows warning and does not call `open_commit`
- [x] Existing sha dispatch test updated to set `is_commit_return = true`
- [x] All 59 tests pass (35 utils + 24 init)