### PR TITLE
docs: remove build and release badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Open GitHub URLs for files, blame, commits, PRs, and repos directly from any Neovim buffer.
 
-[![build](https://github.com/wassimk/gh-navigator.nvim/actions/workflows/build.yml/badge.svg)](https://github.com/wassimk/gh-navigator.nvim/actions/workflows/build.yml) ![release](https://img.shields.io/github/v/release/wassimk/gh-navigator.nvim?logo=github)
-
 ![gh-navigator demo](gh-navigator.gif)
 
 *`:GH!` copies the URL to the clipboard — without `!`, it opens in your browser.*


### PR DESCRIPTION
## Summary
- Remove the build and release badges from the README header