### PR TITLE
docs: add test and lint commands to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ vim.keymap.set('v', '<leader>gB', ':GH! blame<cr>', { desc = 'GH: copy blame sel
 
 ## Development
 
+Run tests and lint:
+
+```shell
+make test
+make lint
+```
+
 Enable the local git hooks (one-time setup):
 
 ```shell

--- a/doc/gh-navigator.nvim.txt
+++ b/doc/gh-navigator.nvim.txt
@@ -185,6 +185,13 @@ No keymaps are set by default. Here are some examples:
 
 DEVELOPMENT                  *gh-navigator.nvim-gh-navigator.nvim-development*
 
+Run tests and lint:
+
+>shell
+    make test
+    make lint
+<
+
 Enable the local git hooks (one-time setup):
 
 >shell


### PR DESCRIPTION
## Summary
- Document `make test` and `make lint` in the Development section