### PR TITLE
fix: use branch name instead of commit SHA in compare URL

### DIFF
--- a/lua/gh-navigator/utils.lua
+++ b/lua/gh-navigator/utils.lua
@@ -56,6 +56,11 @@ local function github_ref(dir)
   return vim.trim(result.stdout)
 end
 
+local function current_branch(dir)
+  local result = run_git(dir, { 'rev-parse', '--abbrev-ref', 'HEAD' })
+  return vim.trim(result.stdout)
+end
+
 local function repo_url(dir)
   local result = run_gh(dir, { 'repo', 'view', '--json', 'url' })
   if result.code ~= 0 then
@@ -184,7 +189,7 @@ function M.open_compare(bang, dir)
     return gh_repo_error_notify()
   end
 
-  open_or_copy(url .. '/compare/' .. github_ref(dir), bang)
+  open_or_copy(url .. '/compare/' .. current_branch(dir), bang)
 end
 
 function M.open_blame(filename, bang, dir)

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -198,14 +198,14 @@ describe('gh-navigator.utils', function()
     before_each(function()
       mock_buf_repo('/mock/repo')
       helpers.set_system_response('repo view', '{"url":"https://github.com/owner/repo"}')
-      helpers.set_system_response('rev-parse HEAD', 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2\n')
+      helpers.set_system_response('rev-parse --abbrev-ref HEAD', 'my-feature-branch\n')
     end)
 
-    it('constructs compare URL with commit SHA and opens it', function()
+    it('constructs compare URL with branch name and opens it', function()
       utils.open_compare(false)
 
       assert.equals(
-        'https://github.com/owner/repo/compare/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        'https://github.com/owner/repo/compare/my-feature-branch',
         helpers.opened_url
       )
     end)
@@ -215,7 +215,7 @@ describe('gh-navigator.utils', function()
 
       assert.equals('+', helpers.last_register)
       assert.equals(
-        'https://github.com/owner/repo/compare/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        'https://github.com/owner/repo/compare/my-feature-branch',
         helpers.last_register_value
       )
     end)


### PR DESCRIPTION
## Summary
- `GH compare` was broken by the SHA change in #33 — it generated `/compare/<sha>` instead of `/compare/<branch>`
- Added a `current_branch()` helper using `git rev-parse --abbrev-ref HEAD` and use it in `open_compare`
- Updated tests to verify the branch name is used in compare URLs

## Test plan
- [x] All existing tests pass
- [ ] Run `GH compare` on a feature branch and verify it opens the correct GitHub compare page