### PR TITLE
chore: add stylua formatting enforcement via hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE=$(jq -r '.tool_input.file_path'); if [[ \"$FILE\" == *.lua ]]; then stylua \"$FILE\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
 
+# Check staged Lua files for stylua formatting
+lua_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.lua')
+
+if [ -n "$lua_files" ]; then
+  if ! command -v stylua &>/dev/null; then
+    echo "WARNING: stylua is not installed — skipping formatting check."
+    echo "Install stylua to enforce Lua formatting: brew install stylua"
+  elif ! stylua --check $lua_files; then
+    echo ""
+    echo "ERROR: stylua formatting violations in staged files."
+    echo "Run 'stylua .' to fix, then re-stage and commit."
+    exit 1
+  fi
+fi
+
 # Only run when README.md is staged
 if ! git diff --cached --name-only | grep -q '^README\.md$'; then
   exit 0

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -204,20 +204,14 @@ describe('gh-navigator.utils', function()
     it('constructs compare URL with branch name and opens it', function()
       utils.open_compare(false)
 
-      assert.equals(
-        'https://github.com/owner/repo/compare/my-feature-branch',
-        helpers.opened_url
-      )
+      assert.equals('https://github.com/owner/repo/compare/my-feature-branch', helpers.opened_url)
     end)
 
     it('copies compare URL to clipboard with bang', function()
       utils.open_compare(true)
 
       assert.equals('+', helpers.last_register)
-      assert.equals(
-        'https://github.com/owner/repo/compare/my-feature-branch',
-        helpers.last_register_value
-      )
+      assert.equals('https://github.com/owner/repo/compare/my-feature-branch', helpers.last_register_value)
     end)
 
     it('notifies when not in a repo', function()


### PR DESCRIPTION
## Summary
- Add Claude Code `PostToolUse` hook to auto-format `.lua` files after every edit
- Add git pre-commit hook to block unformatted Lua from being committed
- Include stylua-reformatted test file

## Test plan
- [ ] Verify Claude Code hook runs stylua after editing a `.lua` file
- [ ] Verify pre-commit hook blocks a commit with stylua violations